### PR TITLE
判別共用体の値をケースなしで表現する方法を提供する(Provide a way to represent values of DUs without cases)

### DIFF
--- a/src/FsYaml/Types.fs
+++ b/src/FsYaml/Types.fs
@@ -94,3 +94,7 @@ module NativeTypes =
     /// オブジェクトからYamlに変換します。
     Represent: RecursiveRepresenter -> Representer
   }
+
+module Attributes =
+  type TaglessUnionAttribute() =
+    inherit Attribute()

--- a/tests/FsYaml.Tests/DumpingTest.fs
+++ b/tests/FsYaml.Tests/DumpingTest.fs
@@ -156,3 +156,22 @@ module DumpUnionTest =
     let actual = represent (NamedFields (fieldA = 3, fieldB = "abc"))
     do! actual |> should equal (mapping [ (plain "NamedFields", mapping [ (plain "fieldA", plain "3"); (plain "fieldB", nonPlain "abc") ]) ])
   }
+
+  [<Attributes.TaglessUnion>]
+  type TaglessCase =
+    | TaglessCase0
+    | TaglessCase1 of int
+    | TaglessCase2 of int * string
+    | TaglessCaseRec of list<TaglessCase>
+
+  let ``タグなし判別共用体を変換できる`` =
+    let body (value, expected) = test {
+      let actual = represent value
+      do! actual |> should equal expected
+    }
+    parameterize {
+      case (TaglessCase0, null')
+      case (TaglessCase1 1, plain "1")
+      case (TaglessCase2 (1, "a"), sequence [plain "1"; nonPlain "a"])
+      run body
+    }

--- a/tests/FsYaml.Tests/LoadingTest.fs
+++ b/tests/FsYaml.Tests/LoadingTest.fs
@@ -357,6 +357,26 @@ module LoadUnionTest =
     do! actual |> should equal (HalfNamedFieldCaseB (1, 2))
   }
 
+  [<Attributes.TaglessUnion>]
+  type TaglessCase =
+    | TaglessCase0
+    | TaglessCase1 of int
+    | TaglessCase2 of int * string
+    | TaglessCaseRec of list<TaglessCase>
+
+  let ``タグなし判別共用体のケースを変換できる`` =
+    let body (yaml, expected) = test {
+      let actual = Yaml.load<TaglessCase> yaml
+      do! actual |> should equal expected
+    }
+    parameterize {
+      case ("null", TaglessCase0)
+      case ("1", TaglessCase1 1)
+      case ("[1, 'a']", TaglessCase2 (1, "a"))
+      case ("[1, []]", TaglessCaseRec ([TaglessCase1 1; TaglessCaseRec []]))
+      run body
+    }
+
   [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
   type UseNullAsTrueValueCase = NullCase | ValueCase1 of int | ValueCase2 of string
     


### PR DESCRIPTION
## 概要
TaglessUnion 属性のついた判別共用体型の値は、YAML 上でケースタグを用いない形で表現されるものとします。

## 議論の余地
- [ ] フィールドなしのケースタグは null に対応します。
- [ ] 同じ型のフィールドがある場合は、常に最初に定義されたケースタグが選択されます。

## 参考
Issue #22
